### PR TITLE
Implement very basic querying

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -5,7 +5,8 @@
             [clojure.repl :refer :all]
             [clojure.tools.namespace.repl :refer (refresh refresh-all)]
             [pathfinder.system :as sys]
-            [midje.repl :refer (autotest)]))
+            [midje.repl :refer (autotest)]
+            [pathfinder.data.data :as data]))
 
 ;;; this file will be loaded by the repl automatically on start up
 
@@ -21,7 +22,7 @@
   (alter-var-root #'system
     (constantly (sys/system {:jetty {:port 9400
                                      :join? false}
-                             :elasticsearch {:endpoint "http://docker:9200"}}))))
+                             :elasticsearch {:endpoint "http://localhost:9200"}}))))
 
 (defn start
   "Starts the current development system."

--- a/src/pathfinder/data/data.clj
+++ b/src/pathfinder/data/data.clj
@@ -1,4 +1,5 @@
 (ns pathfinder.data.data)
 
 (defprotocol Data
-  (stash [this data]))
+  (stash! [this data])
+  (search [this params]))

--- a/src/pathfinder/data/elasticsearch.clj
+++ b/src/pathfinder/data/elasticsearch.clj
@@ -1,12 +1,38 @@
 (ns pathfinder.data.elasticsearch
   (:require [clojurewerkz.elastisch.rest :as esr]
             [clojurewerkz.elastisch.rest.document :as esd]
+            [clojurewerkz.elastisch.rest.index :as esi]
             [pathfinder.data.data :refer [Data]]))
+
+(defn- search-query [params]
+  {:bool
+   {:must [{:term {:project (:project params)}}
+           {:prefix {:path (:path params)}}]}})
+
+(defn- doc-id [data]
+  (format "%s/%s"
+          (get-in data [:meta :project] "UNKNOWN")
+          (get-in data [:meta :path] "UNKNOWN")))
+
+(defn- extract-results [results]
+  {:found (get-in results [:hits :total])
+   :results (->> results :hits :hits (map :_source))})
 
 (deftype ElasticSearch [conn]
   Data
-  (stash [this data]
-    (esd/create conn "docs" "doc" data)))
+  (stash! [this data]
+    (esd/create conn "docs" "doc" data :id (doc-id data))) ;; TODO: set a ttl?
+  (search [this params]
+    (extract-results (esd/search conn "docs" "doc" :query (search-query params)))))
+
+(defn- setup-index! [conn]
+  (let [mappings {:doc {:properties
+                        {:meta {:properties
+                                {:path {:type "string" :index "not_analyzed"}}}}}}]
+    (when-not (esi/exists? conn "docs")
+      (esi/create conn "docs" :mappings mappings))))
 
 (defn ->ElasticSearch [es-config]
-  (ElasticSearch. (esr/connect (:endpoint es-config))))
+  (let [es (esr/connect (:endpoint es-config))]
+    (setup-index! es)
+    (ElasticSearch. es)))

--- a/src/pathfinder/service.clj
+++ b/src/pathfinder/service.clj
@@ -45,13 +45,19 @@
           (store-file [project path body]
             (-> body
                 (analyze/analyze {:project project :path path})
-                (->> (data/stash data))
+                (->> (data/stash! data))
                 present))
 
           (project-routes [project]
             (routes
              (PUT "/*" {body :body {path :*} :params}
-                  (store-file project path (slurp body)))))]
+                  (store-file project path (slurp body)))
+             (GET "/*" {{path :* query :q} :params}
+                  (present (data/search data {:project project
+                                              :path path
+                                              ;; TODO: create something that parses a query
+                                              ;; string in to a data structure. Currently this is ignored.
+                                              :query query})))))]
     (routes
      (context "/projects/:project" [project] (project-routes project))
      (route/not-found "Not Found"))))


### PR DESCRIPTION
Hey guys,

This is a starting point for adding queries. This doesn't actually allow searching but that should be super easy to add on top of this.

Here's an example http session to show what we have now:

```
> put localhost:9400/projects/project/foo/bar/baz.java
Content-Type: text/plain

package org.pathfinder.example;

class Foo {

    public Foo() {

    }

    public int someMethod() {

    }

}
HTTP/1.1 200 OK
Date: Mon, 04 May 2015 15:57:25 GMT
Content-Type: application/json;charset=ISO-8859-1
Content-Length: 95
Server: Jetty(7.6.13.v20130916)

{"_index":"docs","_type":"doc","_id":"project\/foo\/bar\/baz.java","_version":1,"created":true}
> put localhost:9400/projects/project/foo/bar/quux.java
Content-Type: text/plain

package org.pathfinder.example;

class Bar {

    public Bar() {

    }

    public int anotherMethod() {

    }

}
HTTP/1.1 200 OK
Date: Mon, 04 May 2015 15:57:47 GMT
Content-Type: application/json;charset=ISO-8859-1
Content-Length: 96
Server: Jetty(7.6.13.v20130916)

{"_index":"docs","_type":"doc","_id":"project\/foo\/bar\/quux.java","_version":1,"created":true}
> get localhost:9400/projects/project/foo/bar/quux.java
HTTP/1.1 200 OK
Date: Mon, 04 May 2015 15:58:05 GMT
Content-Type: application/json;charset=ISO-8859-1
Content-Length: 618
Server: Jetty(7.6.13.v20130916)

{"found":1,"results":[{"meta":{"path":"foo\/bar\/quux.java","project":"project","type":"java"},"source":"package org.pathfinder.example;\n\nclass Bar {\n\n    public Bar() {\n\n    }\n\n    public int anotherMethod() {\n\n    }\n\n}","definitions":[{"name":"org.pathfinder.example.Bar","type":"class","pos":{"line":3,"column":1,"end-line":13,"end-column":1}},{"name":"org.pathfinder.example.Bar.Bar","type":"constructor","pos":{"line":5,"column":5,"end-line":7,"end-column":5}},{"name":"org.pathfinder.example.Bar.anotherMethod","type":"method","pos":{"line":9,"column":5,"end-line":11,"end-column":5}}],"usages":[]}]}
> get localhost:9400/projects/project/foo/
HTTP/1.1 200 OK
Date: Mon, 04 May 2015 15:58:14 GMT
Content-Type: application/json;charset=ISO-8859-1
Content-Length: 1206
Server: Jetty(7.6.13.v20130916)

{"found":2,"results":[{"meta":{"path":"foo\/bar\/quux.java","project":"project","type":"java"},"source":"package org.pathfinder.example;\n\nclass Bar {\n\n    public Bar() {\n\n    }\n\n    public int anotherMethod() {\n\n    }\n\n}","definitions":[{"name":"org.pathfinder.example.Bar","type":"class","pos":{"line":3,"column":1,"end-line":13,"end-column":1}},{"name":"org.pathfinder.example.Bar.Bar","type":"constructor","pos":{"line":5,"column":5,"end-line":7,"end-column":5}},{"name":"org.pathfinder.example.Bar.anotherMethod","type":"method","pos":{"line":9,"column":5,"end-line":11,"end-column":5}}],"usages":[]},{"meta":{"path":"foo\/bar\/baz.java","project":"project","type":"java"},"source":"package org.pathfinder.example;\n\nclass Foo {\n\n    public Foo() {\n\n    }\n\n    public int someMethod() {\n\n    }\n\n}","definitions":[{"name":"org.pathfinder.example.Foo","type":"class","pos":{"line":3,"column":1,"end-line":13,"end-column":1}},{"name":"org.pathfinder.example.Foo.Foo","type":"constructor","pos":{"line":5,"column":5,"end-line":7,"end-column":5}},{"name":"org.pathfinder.example.Foo.someMethod","type":"method","pos":{"line":9,"column":5,"end-line":11,"end-column":5}}],"usages":[]}]}
> get localhost:9400/projects/project/
HTTP/1.1 200 OK
Date: Mon, 04 May 2015 15:58:17 GMT
Content-Type: application/json;charset=ISO-8859-1
Content-Length: 1206
Server: Jetty(7.6.13.v20130916)

{"found":2,"results":[{"meta":{"path":"foo\/bar\/quux.java","project":"project","type":"java"},"source":"package org.pathfinder.example;\n\nclass Bar {\n\n    public Bar() {\n\n    }\n\n    public int anotherMethod() {\n\n    }\n\n}","definitions":[{"name":"org.pathfinder.example.Bar","type":"class","pos":{"line":3,"column":1,"end-line":13,"end-column":1}},{"name":"org.pathfinder.example.Bar.Bar","type":"constructor","pos":{"line":5,"column":5,"end-line":7,"end-column":5}},{"name":"org.pathfinder.example.Bar.anotherMethod","type":"method","pos":{"line":9,"column":5,"end-line":11,"end-column":5}}],"usages":[]},{"meta":{"path":"foo\/bar\/baz.java","project":"project","type":"java"},"source":"package org.pathfinder.example;\n\nclass Foo {\n\n    public Foo() {\n\n    }\n\n    public int someMethod() {\n\n    }\n\n}","definitions":[{"name":"org.pathfinder.example.Foo","type":"class","pos":{"line":3,"column":1,"end-line":13,"end-column":1}},{"name":"org.pathfinder.example.Foo.Foo","type":"constructor","pos":{"line":5,"column":5,"end-line":7,"end-column":5}},{"name":"org.pathfinder.example.Foo.someMethod","type":"method","pos":{"line":9,"column":5,"end-line":11,"end-column":5}}],"usages":[]}]}
> get localhost:9400/projects/project/foo/ba
HTTP/1.1 200 OK
Date: Mon, 04 May 2015 15:58:21 GMT
Content-Type: application/json;charset=ISO-8859-1
Content-Length: 1206
Server: Jetty(7.6.13.v20130916)

{"found":2,"results":[{"meta":{"path":"foo\/bar\/quux.java","project":"project","type":"java"},"source":"package org.pathfinder.example;\n\nclass Bar {\n\n    public Bar() {\n\n    }\n\n    public int anotherMethod() {\n\n    }\n\n}","definitions":[{"name":"org.pathfinder.example.Bar","type":"class","pos":{"line":3,"column":1,"end-line":13,"end-column":1}},{"name":"org.pathfinder.example.Bar.Bar","type":"constructor","pos":{"line":5,"column":5,"end-line":7,"end-column":5}},{"name":"org.pathfinder.example.Bar.anotherMethod","type":"method","pos":{"line":9,"column":5,"end-line":11,"end-column":5}}],"usages":[]},{"meta":{"path":"foo\/bar\/baz.java","project":"project","type":"java"},"source":"package org.pathfinder.example;\n\nclass Foo {\n\n    public Foo() {\n\n    }\n\n    public int someMethod() {\n\n    }\n\n}","definitions":[{"name":"org.pathfinder.example.Foo","type":"class","pos":{"line":3,"column":1,"end-line":13,"end-column":1}},{"name":"org.pathfinder.example.Foo.Foo","type":"constructor","pos":{"line":5,"column":5,"end-line":7,"end-column":5}},{"name":"org.pathfinder.example.Foo.someMethod","type":"method","pos":{"line":9,"column":5,"end-line":11,"end-column":5}}],"usages":[]}]}
```

If you didn't follow this: I add two docs to the same project with different paths. I can then query for a specific doc or get all the docs that match a prefix. Prefixing like this allows us to show all the docs in a project, directory path etc. This mechanism should easily allow us to scope queries.